### PR TITLE
Constify calls

### DIFF
--- a/include/lautoc.h
+++ b/include/lautoc.h
@@ -28,11 +28,12 @@ void luaA_type_open(void);
 void luaA_type_close(void);
 
 typedef int luaA_Type;
+#define LUAA_INVALID_TYPE -1
 
 #define luaA_type_id(type) luaA_type_add(#type, sizeof(type))
 
 luaA_Type luaA_type_add(char* type, size_t size);
-luaA_Type luaA_type_find(char* type);
+luaA_Type luaA_type_find(const char* type);
 
 char* luaA_type_name(luaA_Type id);
 size_t luaA_type_size(luaA_Type id);
@@ -47,10 +48,10 @@ void luaA_stack_close(void);
 #define luaA_push(L, type, c_in) luaA_push_typeid(L, luaA_type_id(type), c_in)
 #define luaA_to(L, type, c_out, index) luaA_to_typeid(L, luaA_type_id(type), c_out, index)
 
-int luaA_push_typeid(lua_State* L, luaA_Type type_id, void* c_in);
+int luaA_push_typeid(lua_State* L, luaA_Type type_id,const void* c_in);
 void luaA_to_typeid(lua_State* L, luaA_Type type_id, void* c_out, int index);
 
-typedef int (*luaA_Pushfunc)(lua_State*, void*);
+typedef int (*luaA_Pushfunc)(lua_State*,const void*);
 typedef void (*luaA_Tofunc)(lua_State*, void*, int);
 
 #define luaA_conversion(type, push_func, to_func) luaA_conversion_typeid(luaA_type_id(type), push_func, to_func);
@@ -63,39 +64,39 @@ void luaA_conversion_to_typeid(luaA_Type type_id, luaA_Tofunc func);
 
 
 /* native type stack functions */
-int luaA_push_char(lua_State* L, void* c_in);
+int luaA_push_char(lua_State* L,const void* c_in);
 void luaA_to_char(lua_State* L, void* c_out, int index);
-int luaA_push_signed_char(lua_State* L, void* c_in);
+int luaA_push_signed_char(lua_State* L,const void* c_in);
 void luaA_to_signed_char(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_char(lua_State* L, void* c_in);
+int luaA_push_unsigned_char(lua_State* L,const void* c_in);
 void luaA_to_unsigned_char(lua_State* L, void* c_out, int index);
-int luaA_push_short(lua_State* L, void* c_in);
+int luaA_push_short(lua_State* L,const void* c_in);
 void luaA_to_short(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_short(lua_State* L, void* c_in);
+int luaA_push_unsigned_short(lua_State* L,const void* c_in);
 void luaA_to_unsigned_short(lua_State* L, void* c_out, int index);
-int luaA_push_int(lua_State* L, void* c_in);
+int luaA_push_int(lua_State* L,const void* c_in);
 void luaA_to_int(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_int(lua_State* L, void* c_in);
+int luaA_push_unsigned_int(lua_State* L,const void* c_in);
 void luaA_to_unsigned_int(lua_State* L, void* c_out, int index);
-int luaA_push_long(lua_State* L, void* c_in);
+int luaA_push_long(lua_State* L,const void* c_in);
 void luaA_to_long(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_long(lua_State* L, void* c_in);
+int luaA_push_unsigned_long(lua_State* L,const void* c_in);
 void luaA_to_unsigned_long(lua_State* L, void* c_out, int index);
-int luaA_push_long_long(lua_State* L, void* c_in);
+int luaA_push_long_long(lua_State* L,const void* c_in);
 void luaA_to_long_long(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_long_long(lua_State* L, void* c_in);
+int luaA_push_unsigned_long_long(lua_State* L,const void* c_in);
 void luaA_to_unsigned_long_long(lua_State* L, void* c_out, int index);
-int luaA_push_float(lua_State* L, void* c_in);
+int luaA_push_float(lua_State* L,const void* c_in);
 void luaA_to_float(lua_State* L, void* c_out, int index);
-int luaA_push_double(lua_State* L, void* c_in);
+int luaA_push_double(lua_State* L,const void* c_in);
 void luaA_to_double(lua_State* L, void* c_out, int index);
-int luaA_push_long_double(lua_State* L, void* c_in);
+int luaA_push_long_double(lua_State* L,const void* c_in);
 void luaA_to_long_double(lua_State* L, void* c_out, int index);
-int luaA_push_char_ptr(lua_State* L, void* c_in);
+int luaA_push_char_ptr(lua_State* L,const void* c_in);
 void luaA_to_char_ptr(lua_State* L, void* c_out, int index);
-int luaA_push_const_char_ptr(lua_State* L, void* c_in);
+int luaA_push_const_char_ptr(lua_State* L,const void* c_in);
 void luaA_to_const_char_ptr(lua_State* L, void* c_out, int index);
-int luaA_push_void(lua_State* L, void* c_in);
+int luaA_push_void(lua_State* L,const void* c_in);
 
 
 /*
@@ -114,8 +115,8 @@ void luaA_struct_close(void);
 #define luaA_struct_has_member(L, type, member) luaA_struct_has_member_offset_typeid(L, luaA_type_id(type), offsetof(type, member))
 #define luaA_struct_has_member_name(L, type, member) luaA_struct_has_member_name_typeid(L, luaA_type_id(type), member)
 
-int luaA_struct_push_member_offset_typeid(lua_State* L, luaA_Type type, void* cstruct, size_t offset);
-int luaA_struct_push_member_name_typeid(lua_State* L, luaA_Type type, void* cstruct, const char* member);
+int luaA_struct_push_member_offset_typeid(lua_State* L, luaA_Type type,const void* cstruct, size_t offset);
+int luaA_struct_push_member_name_typeid(lua_State* L, luaA_Type type,const void* cstruct, const char* member);
 
 void luaA_struct_to_member_offset_typeid(lua_State* L, luaA_Type type, void* cstruct, size_t offset, int index);
 void luaA_struct_to_member_name_typeid(lua_State* L, luaA_Type type, void* cstruct, const char* member, int index);
@@ -138,7 +139,7 @@ bool luaA_struct_registered_typeid(lua_State* L, luaA_Type type);
 #define luaA_struct_push(L, type, c_in) luaA_struct_push_typeid(L, luaA_type_id(type), c_in)
 #define luaA_struct_to(L, type, c_out, index) luaA_struct_to_typeid(L, luaA_type_id(type), pyobj, c_out, index)
 
-int luaA_struct_push_typeid(lua_State* L, luaA_Type type, void* c_in);
+int luaA_struct_push_typeid(lua_State* L, luaA_Type type,const void* c_in);
 void luaA_struct_to_typeid(lua_State* L, luaA_Type type, void* c_out, int index);
 
 

--- a/src/lautoc_stack.c
+++ b/src/lautoc_stack.c
@@ -41,7 +41,7 @@ void luaA_stack_close(void) {
   
 }
 
-int luaA_push_typeid(lua_State* L, luaA_Type type_id, void* c_in) {
+int luaA_push_typeid(lua_State* L, luaA_Type type_id,const void* c_in) {
   
   luaA_Pushfunc push_func = luaA_hashtable_get(push_table, luaA_type_name(type_id));
   if (push_func != NULL) {
@@ -87,7 +87,7 @@ void luaA_conversion_to_typeid(luaA_Type type_id, luaA_Tofunc func) {
   luaA_hashtable_set(to_table, luaA_type_name(type_id), func);
 }
 
-int luaA_push_char(lua_State* L, void* c_in) {
+int luaA_push_char(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(char*)c_in);
   return 1;
 }
@@ -96,7 +96,7 @@ void luaA_to_char(lua_State* L, void* c_out, int index) {
   *(char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_signed_char(lua_State* L, void* c_in) {
+int luaA_push_signed_char(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(signed char*)c_in);
   return 1;
 }
@@ -105,7 +105,7 @@ void luaA_to_signed_char(lua_State* L, void* c_out, int index) {
   *(signed char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_char(lua_State* L, void* c_in) {
+int luaA_push_unsigned_char(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(unsigned char*)c_in);
   return 1;
 }
@@ -114,7 +114,7 @@ void luaA_to_unsigned_char(lua_State* L, void* c_out, int index) {
   *(unsigned char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_short(lua_State* L, void* c_in) {
+int luaA_push_short(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(short*)c_in);
   return 1;
 }
@@ -123,7 +123,7 @@ void luaA_to_short(lua_State* L, void* c_out, int index) {
   *(short*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_short(lua_State* L, void* c_in) {
+int luaA_push_unsigned_short(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(unsigned short*)c_in);
   return 1;
 }
@@ -132,7 +132,7 @@ void luaA_to_unsigned_short(lua_State* L, void* c_out, int index) {
   *(unsigned short*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_int(lua_State* L, void* c_in) {
+int luaA_push_int(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(int*)c_in);
   return 1;
 }
@@ -141,7 +141,7 @@ void luaA_to_int(lua_State* L, void* c_out, int index) {
   *(int*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_int(lua_State* L, void* c_in) {
+int luaA_push_unsigned_int(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(unsigned int*)c_in);
   return 1;
 }
@@ -150,7 +150,7 @@ void luaA_to_unsigned_int(lua_State* L, void* c_out, int index) {
   *(unsigned int*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_long(lua_State* L, void* c_in) {
+int luaA_push_long(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(long*)c_in);
   return 1;
 }
@@ -159,7 +159,7 @@ void luaA_to_long(lua_State* L, void* c_out, int index) {
   *(long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_long(lua_State* L, void* c_in) {
+int luaA_push_unsigned_long(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(unsigned long*)c_in);
   return 1;
 }
@@ -168,7 +168,7 @@ void luaA_to_unsigned_long(lua_State* L, void* c_out, int index) {
   *(unsigned long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_long_long(lua_State* L, void* c_in) {
+int luaA_push_long_long(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(long long*)c_in);
   return 1;
 }
@@ -177,7 +177,7 @@ void luaA_to_long_long(lua_State* L, void* c_out, int index) {
   *(long long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_long_long(lua_State* L, void* c_in) {
+int luaA_push_unsigned_long_long(lua_State* L,const void* c_in) {
   lua_pushinteger(L, *(unsigned long long*)c_in);
   return 1;
 }
@@ -186,7 +186,7 @@ void luaA_to_unsigned_long_long(lua_State* L, void* c_out, int index) {
   *(unsigned long long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_float(lua_State* L, void* c_in) {
+int luaA_push_float(lua_State* L,const void* c_in) {
   lua_pushnumber(L, *(float*)c_in);
   return 1;
 }
@@ -195,7 +195,7 @@ void luaA_to_float(lua_State* L, void* c_out, int index) {
   *(float*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_double(lua_State* L, void* c_in) {
+int luaA_push_double(lua_State* L,const void* c_in) {
   lua_pushnumber(L, *(double*)c_in);
   return 1;
 }
@@ -204,7 +204,7 @@ void luaA_to_double(lua_State* L, void* c_out, int index) {
   *(double*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_long_double(lua_State* L, void* c_in) {
+int luaA_push_long_double(lua_State* L,const void* c_in) {
   lua_pushnumber(L, *(long double*)c_in);
   return 1;
 }
@@ -213,7 +213,7 @@ void luaA_to_long_double(lua_State* L, void* c_out, int index) {
   *(long double*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_char_ptr(lua_State* L, void* c_in) {
+int luaA_push_char_ptr(lua_State* L,const void* c_in) {
   lua_pushstring(L, *(char**)c_in);
   return 1;
 }
@@ -222,7 +222,7 @@ void luaA_to_char_ptr(lua_State* L, void* c_out, int index) {
   *(char**)c_out = (char*)lua_tostring(L, index);
 }
 
-int luaA_push_const_char_ptr(lua_State* L, void* c_in) {
+int luaA_push_const_char_ptr(lua_State* L,const void* c_in) {
   lua_pushstring(L, *(const char**)c_in);
   return 1;
 }
@@ -231,7 +231,7 @@ void luaA_to_const_char_ptr(lua_State* L, void* c_out, int index) {
   *(const char**)c_out = lua_tostring(L, index);
 }
 
-int luaA_push_void(lua_State* L, void* c_in) {
+int luaA_push_void(lua_State* L,const void* c_in) {
   lua_pushnil(L);
   return 1;
 }

--- a/src/lautoc_struct.c
+++ b/src/lautoc_struct.c
@@ -42,7 +42,7 @@ void luaA_struct_close(void) {
 
 }
 
-int luaA_struct_push_member_offset_typeid(lua_State* L, luaA_Type type, void* cstruct, size_t offset) {
+int luaA_struct_push_member_offset_typeid(lua_State* L, luaA_Type type,const void* cstruct, size_t offset) {
 
   struct_entry* se = luaA_hashtable_get(struct_table, luaA_type_name(type));
   if (se != NULL) {
@@ -63,7 +63,7 @@ int luaA_struct_push_member_offset_typeid(lua_State* L, luaA_Type type, void* cs
   return 0;
 }
 
-int luaA_struct_push_member_name_typeid(lua_State* L, luaA_Type type, void* cstruct, const char* member) {
+int luaA_struct_push_member_name_typeid(lua_State* L, luaA_Type type,const void* cstruct, const char* member) {
 
   struct_entry* se = luaA_hashtable_get(struct_table, luaA_type_name(type));
   if (se != NULL) {
@@ -199,7 +199,7 @@ bool luaA_struct_registered_typeid(lua_State* L, luaA_Type type) {
 
 }
 
-int luaA_struct_push_typeid(lua_State* L, luaA_Type type, void* c_in) {
+int luaA_struct_push_typeid(lua_State* L, luaA_Type type,const void* c_in) {
 
   struct_entry* se = luaA_hashtable_get(struct_table, luaA_type_name(type));
   if (se != NULL) {


### PR DESCRIPTION
Hello

when interfacing my code using luaautoc I had multiple situation where the structure I needed to translate to lua was a const structure (structure is protected by a read/write mutex and I on ly get the read mutex when implementing the __index method)

this commit marks as const some stuff in the API to allow me to do this

thx 

Boucman
