### PR TITLE
add luaA_Type to the signature of PushFunc and ToFunc

### DIFF
--- a/include/lautoc.h
+++ b/include/lautoc.h
@@ -30,8 +30,8 @@ void luaA_type_close(void);
 typedef int luaA_Type;
 #define LUAA_INVALID_TYPE -1
 
-typedef int (*luaA_Pushfunc)(lua_State*,const void*);
-typedef void (*luaA_Tofunc)(lua_State*, void*, int);
+typedef int (*luaA_Pushfunc)(lua_State*, luaA_Type, const void*);
+typedef void (*luaA_Tofunc)(lua_State*, luaA_Type, void*, int);
 
 #define luaA_type_id(type) luaA_type_add(#type, sizeof(type))
 
@@ -66,39 +66,39 @@ void luaA_conversion_to_typeid(luaA_Type type_id, luaA_Tofunc func);
 
 
 /* native type stack functions */
-int luaA_push_char(lua_State* L,const void* c_in);
-void luaA_to_char(lua_State* L, void* c_out, int index);
-int luaA_push_signed_char(lua_State* L,const void* c_in);
-void luaA_to_signed_char(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_char(lua_State* L,const void* c_in);
-void luaA_to_unsigned_char(lua_State* L, void* c_out, int index);
-int luaA_push_short(lua_State* L,const void* c_in);
-void luaA_to_short(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_short(lua_State* L,const void* c_in);
-void luaA_to_unsigned_short(lua_State* L, void* c_out, int index);
-int luaA_push_int(lua_State* L,const void* c_in);
-void luaA_to_int(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_int(lua_State* L,const void* c_in);
-void luaA_to_unsigned_int(lua_State* L, void* c_out, int index);
-int luaA_push_long(lua_State* L,const void* c_in);
-void luaA_to_long(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_long(lua_State* L,const void* c_in);
-void luaA_to_unsigned_long(lua_State* L, void* c_out, int index);
-int luaA_push_long_long(lua_State* L,const void* c_in);
-void luaA_to_long_long(lua_State* L, void* c_out, int index);
-int luaA_push_unsigned_long_long(lua_State* L,const void* c_in);
-void luaA_to_unsigned_long_long(lua_State* L, void* c_out, int index);
-int luaA_push_float(lua_State* L,const void* c_in);
-void luaA_to_float(lua_State* L, void* c_out, int index);
-int luaA_push_double(lua_State* L,const void* c_in);
-void luaA_to_double(lua_State* L, void* c_out, int index);
-int luaA_push_long_double(lua_State* L,const void* c_in);
-void luaA_to_long_double(lua_State* L, void* c_out, int index);
-int luaA_push_char_ptr(lua_State* L,const void* c_in);
-void luaA_to_char_ptr(lua_State* L, void* c_out, int index);
-int luaA_push_const_char_ptr(lua_State* L,const void* c_in);
-void luaA_to_const_char_ptr(lua_State* L, void* c_out, int index);
-int luaA_push_void(lua_State* L,const void* c_in);
+int luaA_push_char(lua_State* L,luaA_Type, const void* c_in);
+void luaA_to_char(lua_State* L, luaA_Type, void* c_out, int index);
+int luaA_push_signed_char(lua_State* L,luaA_Type, const void* c_in);
+void luaA_to_signed_char(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_unsigned_char(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_unsigned_char(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_short(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_short(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_unsigned_short(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_unsigned_short(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_int(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_int(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_unsigned_int(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_unsigned_int(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_long(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_long(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_unsigned_long(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_unsigned_long(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_long_long(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_long_long(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_unsigned_long_long(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_unsigned_long_long(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_float(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_float(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_double(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_double(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_long_double(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_long_double(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_char_ptr(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_char_ptr(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_const_char_ptr(lua_State* L, luaA_Type, const void* c_in);
+void luaA_to_const_char_ptr(lua_State* L, luaA_Type,  void* c_out, int index);
+int luaA_push_void(lua_State* L, luaA_Type, const void* c_in);
 
 
 /*

--- a/src/lautoc_stack.c
+++ b/src/lautoc_stack.c
@@ -62,7 +62,7 @@ int luaA_push_typeid(lua_State* L, luaA_Type type_id,const void* c_in) {
   
   luaA_Pushfunc push_func = luaA_hashtable_get(push_table, luaA_type_name(type_id));
   if (push_func != NULL) {
-    return push_func(L, c_in);
+    return push_func(L, type_id,c_in);
   }
   
   if (luaA_struct_registered_typeid(L, type_id)) {
@@ -78,7 +78,7 @@ void luaA_to_typeid(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   
   luaA_Tofunc to_func = luaA_hashtable_get(to_table, luaA_type_name(type_id));
   if (to_func != NULL) {
-    return to_func(L, c_out, index);
+    return to_func(L, type_id, c_out, index);
   }
   
   if (luaA_struct_registered_typeid(L, type_id)) {
@@ -104,151 +104,151 @@ void luaA_conversion_to_typeid(luaA_Type type_id, luaA_Tofunc func) {
   luaA_hashtable_set(to_table, luaA_type_name(type_id), func);
 }
 
-int luaA_push_char(lua_State* L,const void* c_in) {
+int luaA_push_char(lua_State* L, luaA_Type type_id, const void* c_in) {
   lua_pushinteger(L, *(char*)c_in);
   return 1;
 }
 
-void luaA_to_char(lua_State* L, void* c_out, int index) {
+void luaA_to_char(lua_State* L, luaA_Type type_id,  void* c_out, int index) {
   *(char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_signed_char(lua_State* L,const void* c_in) {
+int luaA_push_signed_char(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(signed char*)c_in);
   return 1;
 }
 
-void luaA_to_signed_char(lua_State* L, void* c_out, int index) {
+void luaA_to_signed_char(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(signed char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_char(lua_State* L,const void* c_in) {
+int luaA_push_unsigned_char(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(unsigned char*)c_in);
   return 1;
 }
 
-void luaA_to_unsigned_char(lua_State* L, void* c_out, int index) {
+void luaA_to_unsigned_char(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(unsigned char*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_short(lua_State* L,const void* c_in) {
+int luaA_push_short(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(short*)c_in);
   return 1;
 }
 
-void luaA_to_short(lua_State* L, void* c_out, int index) {
+void luaA_to_short(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(short*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_short(lua_State* L,const void* c_in) {
+int luaA_push_unsigned_short(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(unsigned short*)c_in);
   return 1;
 }
 
-void luaA_to_unsigned_short(lua_State* L, void* c_out, int index) {
+void luaA_to_unsigned_short(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(unsigned short*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_int(lua_State* L,const void* c_in) {
+int luaA_push_int(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(int*)c_in);
   return 1;
 }
 
-void luaA_to_int(lua_State* L, void* c_out, int index) {
+void luaA_to_int(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(int*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_int(lua_State* L,const void* c_in) {
+int luaA_push_unsigned_int(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(unsigned int*)c_in);
   return 1;
 }
 
-void luaA_to_unsigned_int(lua_State* L, void* c_out, int index) {
+void luaA_to_unsigned_int(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(unsigned int*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_long(lua_State* L,const void* c_in) {
+int luaA_push_long(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(long*)c_in);
   return 1;
 }
 
-void luaA_to_long(lua_State* L, void* c_out, int index) {
+void luaA_to_long(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_long(lua_State* L,const void* c_in) {
+int luaA_push_unsigned_long(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(unsigned long*)c_in);
   return 1;
 }
 
-void luaA_to_unsigned_long(lua_State* L, void* c_out, int index) {
+void luaA_to_unsigned_long(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(unsigned long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_long_long(lua_State* L,const void* c_in) {
+int luaA_push_long_long(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(long long*)c_in);
   return 1;
 }
 
-void luaA_to_long_long(lua_State* L, void* c_out, int index) {
+void luaA_to_long_long(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(long long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_unsigned_long_long(lua_State* L,const void* c_in) {
+int luaA_push_unsigned_long_long(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushinteger(L, *(unsigned long long*)c_in);
   return 1;
 }
 
-void luaA_to_unsigned_long_long(lua_State* L, void* c_out, int index) {
+void luaA_to_unsigned_long_long(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(unsigned long long*)c_out = lua_tointeger(L, index);
 }
 
-int luaA_push_float(lua_State* L,const void* c_in) {
+int luaA_push_float(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushnumber(L, *(float*)c_in);
   return 1;
 }
 
-void luaA_to_float(lua_State* L, void* c_out, int index) {
+void luaA_to_float(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(float*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_double(lua_State* L,const void* c_in) {
+int luaA_push_double(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushnumber(L, *(double*)c_in);
   return 1;
 }
 
-void luaA_to_double(lua_State* L, void* c_out, int index) {
+void luaA_to_double(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(double*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_long_double(lua_State* L,const void* c_in) {
+int luaA_push_long_double(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushnumber(L, *(long double*)c_in);
   return 1;
 }
 
-void luaA_to_long_double(lua_State* L, void* c_out, int index) {
+void luaA_to_long_double(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(long double*)c_out = lua_tonumber(L, index);
 }
 
-int luaA_push_char_ptr(lua_State* L,const void* c_in) {
+int luaA_push_char_ptr(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushstring(L, *(char**)c_in);
   return 1;
 }
 
-void luaA_to_char_ptr(lua_State* L, void* c_out, int index) {
+void luaA_to_char_ptr(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(char**)c_out = (char*)lua_tostring(L, index);
 }
 
-int luaA_push_const_char_ptr(lua_State* L,const void* c_in) {
+int luaA_push_const_char_ptr(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushstring(L, *(const char**)c_in);
   return 1;
 }
 
-void luaA_to_const_char_ptr(lua_State* L, void* c_out, int index) {
+void luaA_to_const_char_ptr(lua_State* L, luaA_Type type_id, void* c_out, int index) {
   *(const char**)c_out = lua_tostring(L, index);
 }
 
-int luaA_push_void(lua_State* L,const void* c_in) {
+int luaA_push_void(lua_State* L, luaA_Type type_id,const void* c_in) {
   lua_pushnil(L);
   return 1;
 }


### PR DESCRIPTION
this ease code factoring since these functions can now be reused with multiple types. 

In particular it allows to find the size of the type in the push function and thus use malloc/memcpy to create a full user data.

the drawback is that it breaks compatibility since we change the signature of the functions
