### PR TITLE
autogen.lua:52: attempt to call method 'split' (a nil value)

### DIFF
--- a/autogen.lua
+++ b/autogen.lua
@@ -19,7 +19,14 @@ function findall(text, pattern)
   end
   return matches
 end
-  
+
+function string:split(sep)
+  local sep, fields = sep or ":", {}
+  local pattern = string.format("([^%s]+)", sep)
+  self:gsub(pattern, function(c) fields[#fields+1] = c end)
+  return fields
+end
+
 typedefs = findall(text, "typedef struct {.-} %w-;")
 funcdefs = findall(text, "[%w%*]- [%w_]-%(.-%);")
 
@@ -28,13 +35,6 @@ print("")
 for k,v in pairs(typedefs) do
   local _, _, members, typename = string.find(v, "typedef struct {(.-)} (%w-);")
   print(string.format("luaA_struct(%s);", typename))
-  
-  function string:split(sep)
-    local sep, fields = sep or ":", {}
-    local pattern = string.format("([^%s]+)", sep)
-    self:gsub(pattern, function(c) fields[#fields+1] = c end)
-    return fields
-  end
   
   for _, mem in pairs(members:split(";")) do
     local meminfo = mem:split(" ")


### PR DESCRIPTION
Getting this in both lua 5.1 and 5.2 installed using apt on Ubuntu 12.04.2 LTS.

```
lua: autogen.lua:52: attempt to call method 'split' (a nil value)
stack traceback:
        autogen.lua:52: in main chunk
        [C]: in ?
```

The attached patch fixed it for me.
