### PR TITLE
luaA_call_entry(): fix rare memory leak

### DIFF
--- a/lautoc.c
+++ b/lautoc.c
@@ -1164,6 +1164,9 @@ static int luaA_call_entry(lua_State* L) {
     arg_heap = true;
     arg_data = malloc(arg_size);
     if (arg_data == NULL) {
+      if (ret_heap) {
+        free(ret_data);
+      }
       lua_pushfstring(L, "luaA_call: Out of memory!");
       lua_error(L);
       return 0;


### PR DESCRIPTION
When using heap and failing to allocate memory for arg_data,
we would leak memory for ret_data.
In reality, probably really rare to happen.

Cherry-picked from darktable-org/darktable@d60baf4648ad4739971410f7c1499ab70b6967d4