### PR TITLE
Fixing scope problem in lautoc.lua

### DIFF
--- a/lautoc.lua
+++ b/lautoc.lua
@@ -96,7 +96,7 @@ for k,v in pairs(funcs) do
 
   local fstring = string.format("luaA_function(%s, %s", name, typename)
   for _, v in pairs(argtypes) do
-    local fstring = fstring .. string.format(", %s", v)
+    fstring = fstring .. string.format(", %s", v)
   end
   local fstring = fstring .. ");"
   


### PR DESCRIPTION
The local copy of fstring gets discarded at the end of each iteration, meaning the argument types were not actually being written to the output.