### PR TITLE
add lua implementation macro

### DIFF
--- a/lautoc.h
+++ b/lautoc.h
@@ -8,9 +8,12 @@
 #ifndef lautoc_h
 #define lautoc_h
 
+#ifndef LUAA_LUAIMPLEMENTATION
+#define LUAA_LUAIMPLEMENTATION
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
+#endif
 
 #include <stddef.h>
 #include <stdbool.h>


### PR DESCRIPTION
Sometimes I want to use another lua implementation, so I need a macro to ignore the lua inclusion.